### PR TITLE
Allow for very large protocol version numbers

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -6,7 +6,7 @@ use thiserror::Error;
 /// An error from the Minecraft networking protocol.
 #[derive(Error, Debug)]
 pub enum MinecraftProtocolError {
-    /// VarInt data was invalid according to the spec.
+    /// `VarInt` data was invalid according to the spec.
     #[error("invalid varint data")]
     InvalidVarInt,
 

--- a/src/rcon.rs
+++ b/src/rcon.rs
@@ -4,6 +4,7 @@
 mod client;
 mod packet;
 
+#[allow(clippy::module_name_repetitions)]
 pub use client::RconClient;
 
 const MAX_LEN_CLIENTBOUND: usize = 4096;

--- a/src/rcon/client.rs
+++ b/src/rcon/client.rs
@@ -36,7 +36,7 @@ pub struct RconClient {
 }
 
 impl RconClient {
-    /// Construct an [RconClient] that connects to the given host and port.
+    /// Construct an [`RconClient`] that connects to the given host and port.
     /// Note: to authenticate use the `authenticate` method, this method does not take a password.
     ///
     /// # Arguments
@@ -61,7 +61,7 @@ impl RconClient {
 
     /// Authenticate with the server, with the given password.
     ///
-    /// If authentication fails, this method will return [RconProtocolError::AuthFailed].
+    /// If authentication fails, this method will return [`RconProtocolError::AuthFailed`].
     ///
     /// # Arguments
     /// * `password` - A string slice that holds the RCON password.

--- a/src/rcon/client.rs
+++ b/src/rcon/client.rs
@@ -30,6 +30,7 @@ use tokio::{
 ///     Ok(())
 /// }
 /// ```
+#[allow(clippy::module_name_repetitions)]
 #[derive(Debug)]
 pub struct RconClient {
     socket: TcpStream,

--- a/src/status/data.rs
+++ b/src/status/data.rs
@@ -121,6 +121,7 @@ pub struct ChatComponentObject {
     /// * `minecraft:uniform` - Unicode font
     /// * `minecraft:alt` - enchanting table font
     /// * `minecraft:default` - font based on resource pack (1.16+)
+    ///
     /// Any other value can be ignored
     pub font: Option<String>,
 

--- a/src/status/data.rs
+++ b/src/status/data.rs
@@ -71,7 +71,7 @@ pub struct Version {
     ///
     /// See [the wiki.vg page](https://wiki.vg/Protocol_version_numbers) for a
     /// reference on what versions these correspond to.
-    pub protocol: u16,
+    pub protocol: u64,
 }
 
 /// Represents a chat object (the MOTD is sent as a chat object).

--- a/src/status/data.rs
+++ b/src/status/data.rs
@@ -146,7 +146,7 @@ pub struct ChatComponentObject {
     pub extra: Option<Vec<ChatObject>>,
 }
 
-/// ClickEvent data for a chat component
+/// `ClickEvent` data for a chat component
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ChatClickEvent {
     // These are not renamed on purpose. (server returns them in snake_case)
@@ -169,7 +169,7 @@ pub struct ChatClickEvent {
     pub copy_to_clipboard: Option<String>,
 }
 
-/// HoverEvent data for a chat component
+/// `HoverEvent` data for a chat component
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ChatHoverEvent {
     // These are not renamed on purpose. (server returns them in snake_case)

--- a/src/varint.rs
+++ b/src/varint.rs
@@ -107,7 +107,7 @@ mod tests {
             (i32::MIN, b"\x80\x80\x80\x80\x08"),
         ]);
 
-        for (k, v) in cases.into_iter() {
+        for (k, v) in cases {
             let varint: VarInt = k.into();
             assert_eq!(varint.bytes.len(), v.len());
             assert_eq!(varint.bytes, v);
@@ -140,7 +140,7 @@ mod tests {
         })
         .collect::<HashMap<_, _>>();
 
-        for (k, v) in cases.into_iter() {
+        for (k, v) in cases {
             let x: Result<i32, _> = v.try_into();
 
             if let Err(MinecraftProtocolError::InvalidVarInt) = x {


### PR DESCRIPTION
Snapshot or in-dev versions of Minecraft may send very large version numbers. We should support these when deserializing the object.