### PR TITLE
changed version protocol number from unsigned to signed int

### DIFF
--- a/src/status/data.rs
+++ b/src/status/data.rs
@@ -71,7 +71,7 @@ pub struct Version {
     ///
     /// See [the wiki.vg page](https://wiki.vg/Protocol_version_numbers) for a
     /// reference on what versions these correspond to.
-    pub protocol: u64,
+    pub protocol: i64,
 }
 
 /// Represents a chat object (the MOTD is sent as a chat object).


### PR DESCRIPTION
While i was using that i noticed that if a server returns -1 as the protocol version like some servers do, you get an invalid status response error. This should fix that.