### PR TITLE
make motd into an option

### DIFF
--- a/src/status/data.rs
+++ b/src/status/data.rs
@@ -17,7 +17,7 @@ pub struct StatusResponse {
 
     /// The "motd" - message shown in the server list by the client.
     #[serde(rename = "description")]
-    pub motd: ChatObject,
+    pub motd: Option<ChatObject>,
 
     /// URI to the server's favicon.
     pub favicon: Option<String>,


### PR DESCRIPTION
I noticed that if a server does not have a motd, it cannot parse the status. Changing motd to an option should fix this.